### PR TITLE
#164368711 Get Unread Messages with endpoint Test

### DIFF
--- a/src/v1/__tests__/messages.spec.js
+++ b/src/v1/__tests__/messages.spec.js
@@ -14,10 +14,22 @@ const messageRoute = '/api/v1/messages';
 const userRoute = '/api/v1/auth'
 
 
-describe('Test to get all sent emails', () => {
+describe('Test to get emails, should return 404', () => {
     it('should get a 404 status code', (done) => {
         chai.request(server)
             .get(`${messageRoute}/sent`)
+            .end((req, res) => {
+                res.should.have.status(404);
+                res.should.be.json;
+                res.body.should.have.property('error');
+                res.body.should.be.a('object');
+                done();
+            })
+    })
+
+    it('should get a 404 status code for unread messages', (done) => {
+        chai.request(server)
+            .get(`${messageRoute}/unread`)
             .end((req, res) => {
                 res.should.have.status(404);
                 res.should.be.json;
@@ -92,10 +104,24 @@ describe('Validation error to post message', () => {
     })
 });
 
-describe('Test to get all sent emails', () => {
+
+
+describe('Test to get all emails', () => {
     it('should successfully get all sent emails', (done) => {
         chai.request(server)
             .get(`${messageRoute}/sent`)
+            .end((req, res) => {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.have.property('data');
+                res.body.should.be.a('object');
+                done();
+            })
+    })
+
+    it('should successfully get all unread emails', (done) => {
+        chai.request(server)
+            .get(`${messageRoute}/unread`)
             .end((req, res) => {
                 res.should.have.status(200);
                 res.should.be.json;

--- a/src/v1/__tests__/mockData.js
+++ b/src/v1/__tests__/mockData.js
@@ -45,6 +45,7 @@ export default {
         receiverId: '289h3g8598658902389b934v',
         receiverEmail: 'Malalumbu@sa.com',
     },
+    
 
     messageDraft: {
         subject: "Mediocrity at Felmish",

--- a/src/v1/controllers/messagesControllers.js
+++ b/src/v1/controllers/messagesControllers.js
@@ -22,11 +22,19 @@ const Messages = {
     },
 
     findSentMessage(req, res) {
-        const allSentMessages = messagesModels.sentMessages();
+        const allSentMessages = messagesModels.allSentMails();
         if (allSentMessages.length < 1) {
             return res.status(404).json({ status: 404, error: 'There are no sent messages at the moment' });
         }
-        return res.status(200).json({ status: 200, data: allSentMessages });
+        return res.status(200).json({ status: 200, data: [allSentMessages] });
+    },
+
+    findUnreadMessages(req, res) {
+        const allUnreadMessages = messagesModels.unreadMails();
+        if(allUnreadMessages < 1) {
+            return res.status(404).json({ status: 404, error: 'There are no unread messages at the moment'})
+        }
+        return res.status(200).json({status: 404, data: [allUnreadMessages]});
     },
 }
 

--- a/src/v1/models/messagesModels.js
+++ b/src/v1/models/messagesModels.js
@@ -22,9 +22,14 @@ class Messages {
         return newMessage;
     }
 
-    sentMessages() {
+    allSentMails() {
         const allMessages = this.messages;
         return allMessages.filter(message => message.status == 'sent');
+    }
+
+    unreadMails(){
+        const unreadMessages = this.messages;
+        return unreadMessages.filter(message => message.status != 'read');
     }
 }
 

--- a/src/v1/routes/messagesRoutes.js
+++ b/src/v1/routes/messagesRoutes.js
@@ -24,5 +24,6 @@ const router = express.Router();
 
 router.post('/', validateBody(schemas.authSchema), passportJWT, messagesControllers.createMessage);
 router.get('/sent', messagesControllers.findSentMessage);
+router.get('/unread', messagesControllers.findUnreadMessages);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Enables a registered user to composeMessages


#### Description of Task to be completed?
Have the endpoint to post messages working
- GET /api/v1/messages/unread


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **GET** request to /api/v1/auth/messages/unread, if there are any unread messages, then you would see them


#### Any background context you want to provide?
You can first register as a user and post a message with status as  _'draft'_ or  _'sent'_ to make messages available when you search


#### What are the relevant pivotal tracker stories?
#164368711 