### PR TITLE
#164368660 Get all received Emails feature and test

### DIFF
--- a/src/v1/__tests__/messages.spec.js
+++ b/src/v1/__tests__/messages.spec.js
@@ -38,6 +38,18 @@ describe('Test to get emails, should return 404', () => {
                 done();
             })
     })
+
+    it('should get a 404 status code for received messages', (done) => {
+        chai.request(server)
+            .get(`${messageRoute}/received`)
+            .end((req, res) => {
+                res.should.have.status(404);
+                res.should.be.json;
+                res.body.should.have.property('error');
+                res.body.should.be.a('object');
+                done();
+            })
+    })
 })
 
 describe('User Compose messages', () => {
@@ -122,6 +134,18 @@ describe('Test to get all emails', () => {
     it('should successfully get all unread emails', (done) => {
         chai.request(server)
             .get(`${messageRoute}/unread`)
+            .end((req, res) => {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.have.property('data');
+                res.body.should.be.a('object');
+                done();
+            })
+    })
+
+    it('should successfully get all received emails', (done) => {
+        chai.request(server)
+            .get(`${messageRoute}/received`)
             .end((req, res) => {
                 res.should.have.status(200);
                 res.should.be.json;

--- a/src/v1/controllers/messagesControllers.js
+++ b/src/v1/controllers/messagesControllers.js
@@ -31,11 +31,19 @@ const Messages = {
 
     findUnreadMessages(req, res) {
         const allUnreadMessages = messagesModels.unreadMails();
-        if(allUnreadMessages < 1) {
-            return res.status(404).json({ status: 404, error: 'There are no unread messages at the moment'})
+        if (allUnreadMessages < 1) {
+            return res.status(404).json({ status: 404, error: 'There are no unread messages at the moment' })
         }
-        return res.status(200).json({status: 404, data: [allUnreadMessages]});
+        return res.status(200).json({ status: 200, data: [allUnreadMessages] });
     },
+
+    findReceivedMails(req, res) {
+        const allReceievedMessages = messagesModels.receivedMails();
+        if (allReceievedMessages.length < 1) {
+            return res.status(404).json({ status: 404, error: 'There are no received messages at the moment' });
+        }
+        return res.status(200).json({ status: 200, data: [allReceievedMessages] });
+    }
 }
 
 export default Messages;

--- a/src/v1/models/messagesModels.js
+++ b/src/v1/models/messagesModels.js
@@ -28,8 +28,13 @@ class Messages {
     }
 
     unreadMails(){
-        const unreadMessages = this.messages;
-        return unreadMessages.filter(message => message.status != 'read');
+        const allMessages = this.messages;
+        return allMessages.filter(message => message.status != 'read');
+    }
+
+    receivedMails() {
+        const allMessages = this.messages;
+        return allMessages.filter(message => message.status == 'sent' || 'read');
     }
 }
 

--- a/src/v1/routes/messagesRoutes.js
+++ b/src/v1/routes/messagesRoutes.js
@@ -25,5 +25,6 @@ const router = express.Router();
 router.post('/', validateBody(schemas.authSchema), passportJWT, messagesControllers.createMessage);
 router.get('/sent', messagesControllers.findSentMessage);
 router.get('/unread', messagesControllers.findUnreadMessages);
+router.get('/received', messagesControllers.findReceivedMails)
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Enables user to get all received email

#### Description of Task to be completed?
Have the endpoint to post messages working
- GET /api/v1/messages/received


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **GET** request to /api/v1/auth/messages/received

#### Any background context you want to provide?
To get received emails, ensure that a registered user posts emails with _'sent'_ or _'draft'_ status

#### What are the relevant pivotal tracker stories?
#164368660 