### PR TITLE
#164395409 Solves bug on postDraft Mails and GET received Mails

### DIFF
--- a/src/v1/__tests__/messages.spec.js
+++ b/src/v1/__tests__/messages.spec.js
@@ -3,7 +3,7 @@ import chaiHttp from 'chai-http';
 import server from './../../server';
 import mockData from './mockData';
 
-const { incompleteMessage, userForMessageValidation, message, userForComposeMail, specificUser, messageDraft } = mockData;
+const { incompleteMessage, userForMessageValidation, message, userForComposeMail, specificUser, messageDraft, messageSent } = mockData;
 
 chai.use(chaiHttp);
 
@@ -96,17 +96,31 @@ describe('User Compose messages', () => {
                         res.body.should.have.property('data');
                         res.body.should.be.a('object');
 
-                        // test for a draft message without reciveremail/id
+                        //test for a draft message without reciveremail/id
                         chai.request(server)
                             .post(`${messageRoute}/`)
                             .set('Authorization', `${tokenContainer.token}`)
                             .send(messageDraft)
                             .end((req, res) => {
-                                res.should.have.status(400);
+                                console.log(res.error);
+                                res.should.have.status(201);
                                 res.should.be.json;
-                                res.body.should.have.property('error');
+                                res.body.should.have.property('data');
                                 res.body.should.be.a('object');
-                                done();
+
+
+                                //Sent message without a reciver should fail
+                                chai.request(server)
+                                    .post(`${messageRoute}/`)
+                                    .set('Authorization', `${tokenContainer.token}`)
+                                    .send(messageSent)
+                                    .end((req, res) => {
+                                        res.should.have.status(400);
+                                        res.should.be.json;
+                                        res.body.should.have.property('error');
+                                        res.body.should.be.a('object');
+                                        done();
+                                    })
                             })
                     })
             });

--- a/src/v1/__tests__/mockData.js
+++ b/src/v1/__tests__/mockData.js
@@ -61,6 +61,13 @@ export default {
         status: "draft"
     },
 
+    messageSent: {
+        subject: "Mediocrity at Felmish",
+        message: "I really found the level of mediocrity at a so-called Flemish company very disappointing",
+        parentMessageId: "None",
+        status: "sent"
+    },
+
     incompleteMessage: {
         subject: "Mediocrity at Felmish",
         parentMessageId: "None",

--- a/src/v1/controllers/messagesControllers.js
+++ b/src/v1/controllers/messagesControllers.js
@@ -11,10 +11,9 @@ const Messages = {
                 return res.status(401).json({ status: 401, error: 'Authentication Error: Email or password does not match' });
             }
             const request = req.value.body;
-            if (request.status != 'draft' && !request.receiverId || !request.receiverEmail) {
+            if (request.status !== 'draft' && (!request.receiverEmail || !request.receiverId)) {
                 return res.status(400).json({ status: 400, error: 'receiverEmail or reciverId cannot be empty' });
             }
-            request.senderId = userExist.id;
             request.senderEmail = userExist.email;
             const sendMessage = messagesModels.sendMail(request);
             return res.status(201).json({ status: 201, data: [sendMessage] });
@@ -55,12 +54,12 @@ const Messages = {
 
     deleteSpecificMail(req, res) {
         const specificMail = messagesModels.specificMail(req.params.id);
-        if(!specificMail) {
-            return res.status(404).json({ status: 404, error: 'Failed Delete, specified message does not exist'})
+        if (!specificMail) {
+            return res.status(404).json({ status: 404, error: 'Failed Delete, specified message does not exist' })
         }
         messagesModels.deleteMail(req.params.id);
         //response here should be 204, but since specification requires a res.body, I would be using 200
-        return res.status(200).json({data: 'Message deleted'})
+        return res.status(200).json({ data: 'Message deleted' })
     }
 }
 

--- a/src/v1/models/messagesModels.js
+++ b/src/v1/models/messagesModels.js
@@ -34,7 +34,7 @@ class Messages {
 
     receivedMails() {
         const allMessages = this.messages;
-        return allMessages.filter(message => message.status == 'sent' || 'read');
+        return allMessages.filter(message => message.status == 'sent' || message.status == 'read');
     }
 
     specificMail(messageId) {


### PR DESCRIPTION
#### What does this PR do?
- User can specifically get only 'sent'and 'read' mails as **received** mails
- User can POST draft messages without details of the recipient


#### Description of Task to be completed?
Have the endpoint to post messages working
- POST /api/v1/messages/
- GET /api/v1/messages/received


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v1/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a post request to /api/v1/messages/


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164395409 