### PR TITLE
#164679785 User can GET Specific Mail (version-2)

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,5 @@
 ## other configuration excluded from example...
 exclude_patterns:
-- "src/v1/__tests__/*.js"
+- "src/v2/__tests__/*.js"
 - "UI/"
-- "src/v2/"
+- "src/v1/"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 bash.exe.stackdump
 notes
 .eslintignore
+src/v1/

--- a/src/v2/__tests__/messages.spec.js
+++ b/src/v2/__tests__/messages.spec.js
@@ -52,6 +52,7 @@ describe('Succesful User message actions', () => {
         res.should.be.json;
         res.body.should.have.property('data');
         res.body.should.be.a('object');
+        expect(res.body.data[0].parentMessageId).to.not.be.null;
         done();
       });
   });
@@ -66,6 +67,33 @@ describe('Succesful User message actions', () => {
         res.should.be.json;
         res.body.should.have.property('data');
         res.body.should.be.a('object');
+        expect(res.body.data[0]).to.have.own.property('subject', 'Media and Telcoms');
+        done();
+      });
+  });
+
+  it('should return a 200 status code for an existing specific message', (done) => {
+    chai.request(server)
+      .get(`${messagesRoute}/1`)
+      .set('Authorization', `${generated.token}`)
+      .end((req, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        expect(res.body.data[0]).to.have.property('message');
+        expect(res.body.data[0]).to.have.own.property('subject', 'Mediocrity at Felmish');
+        done();
+      });
+  });
+
+  it('should return a 404 status code for an non-existing specific message', (done) => {
+    chai.request(server)
+      .get(`${messagesRoute}/21`)
+      .set('Authorization', `${generated.token}`)
+      .end((req, res) => {
+        res.should.have.status(404);
+        res.body.should.be.a('object');
+        expect(res.body).to.have.property('error');
+        expect(res.body).to.have.own.property('error', 'Not Found, you do not have a message with id=21');
         done();
       });
   });
@@ -100,4 +128,5 @@ describe('Failed Message attempts', () => {
         done();
       });
   });
+
 });

--- a/src/v2/controllers/messagesControllers.js
+++ b/src/v2/controllers/messagesControllers.js
@@ -38,6 +38,36 @@ const Mail = {
       }
     })(req, res);
   },
+
+  // Method to get a specific mail
+  async getSpecificMail(req, res) {
+    passport.authenticate('jwt', { session: false }, async (err, user) => {
+      if (err) { return res.status(400).json({ status: 400, error: err }); }
+      if (!user) {
+        return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' });
+      }
+      const text = `SELECT * FROM messagesTable 
+      WHERE id=$1 AND (receiverEmail=$2 OR senderEmail=$2)`;
+      const values = [req.params.id, user.email];
+      try {
+        const { rows } = await db.query(text, values);
+        if (!rows[0]) {
+          return res.status(404).json({ status: 404, error: `Not Found, you do not have a message with id=${req.params.id}` });
+        }
+        // If the receiver is the one mjaking a request to the specific message
+        // Then the message status should change to read if it was not yet read
+        if (rows[0].status === 'inbox' && rows[0].receiveremail === user.email) {
+          const updateText = `UPDATE messagesTable
+          SET status=$1`;
+          const updateValue = ['read'];
+          await db.query(updateText, updateValue);
+        }
+        return res.status(200).json({ status: 200, data: [rows[0]] });
+      } catch (error) {
+        return res.status(400).json({ status: 400, error: `${error.name}, ${error.message}` });
+      }
+    })(req, res);
+  },
 };
 
 

--- a/src/v2/routes/messagesRoutes.js
+++ b/src/v2/routes/messagesRoutes.js
@@ -21,5 +21,6 @@ const passportJWT = function (req, res, next) {
 const router = express.Router();
 
 router.post('/', validateBody(schemas.composeMail), passportJWT, messagesControllers.composeMail);
+router.get('/:id', messagesControllers.getSpecificMail);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can get specific Mail

#### Description of Task to be completed?
- registered user can get mails he/she sent/received
- route to get specific mail
- controller to get specific mail
- test cases to get specific mail
- ignore all files from version-1
- test coverage only version-2
- user must be logged in to get specific mail

#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a post request to /api/v2/messages/, use the same _Authorization_ header to make a request to the get the specific message you just posted by sending a POST request to /api/v2/messages/:id where **:id**=id of the initially sent message

#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164679785