### PR TITLE
#164680671 Get all Received Messages

### DIFF
--- a/src/v2/__tests__/messages.spec.js
+++ b/src/v2/__tests__/messages.spec.js
@@ -137,7 +137,7 @@ describe('Succesful User message actions', () => {
       });
   });
 
-  it('should return a 200 status code', (done) => {
+  it('should return a 404 status code', (done) => {
     chai.request(server)
       .get(`${messagesRoute}/unread`)
       .set('Authorization', `${generated.token}`)
@@ -147,6 +147,20 @@ describe('Succesful User message actions', () => {
         res.body.should.have.property('error');
         res.body.should.be.a('object');
         expect(res.body).to.have.own.property('error', `Not Found, You do not have any unread emails at the moment`);
+        done();
+      });
+  });
+
+  it('should return a 404 status code when there are no received emails', (done) => {
+    chai.request(server)
+      .get(`${messagesRoute}/received`)
+      .set('Authorization', `${generated.token}`)
+      .end((req, res) => {
+        res.should.have.status(404);
+        res.should.be.json;
+        res.body.should.have.property('error');
+        res.body.should.be.a('object');
+        expect(res.body).to.have.own.property('error', `Not Found, You do not have any emails in your inbox at the moment`);
         done();
       });
   });
@@ -233,6 +247,19 @@ describe('User/messages actions', () => {
       it('should return a 200 status code', (done) => {
         chai.request(server)
           .get(`${messagesRoute}/unread`)
+          .set('Authorization', `${container.receiverToken}`)
+          .end((req, res) => {
+            res.should.have.status(200);
+            res.should.be.json;
+            res.body.should.have.property('data');
+            res.body.should.be.a('object');
+            done();
+          });
+      });
+
+      it('should return a 200 status code to get all received emails', (done) => {
+        chai.request(server)
+          .get(`${messagesRoute}/received`)
           .set('Authorization', `${container.receiverToken}`)
           .end((req, res) => {
             res.should.have.status(200);

--- a/src/v2/controllers/messagesControllers.js
+++ b/src/v2/controllers/messagesControllers.js
@@ -128,7 +128,27 @@ const Mail = {
         return res.status(400).json({status: 400, error })
       }
     })(req, res);
-  }
+  }, 
+  
+  async allReceivedMails(req, res) {
+    passport.authenticate('jwt', {session:false}, async(err, user) => {
+      if (err) { return res.status(400).json({ status: 400, error: err }); }
+      if (!user) {
+        return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' });
+      }
+      const text = `SELECT * FROM messagesTable WHERE receiverEmail=$1 AND (status=$2 OR status=$3)`;
+      const values = [user.email, 'inbox', 'read'];
+      try {
+        const {rows} = await db.query(text, values);
+        if(!rows[0]){
+          return res.status(404).json({status: 404, error: `Not Found, You do not have any emails in your inbox at the moment`});
+        }
+        return res.status(200).json({ status: 200, data: rows })
+      } catch (error) {
+        return res.status(400).json({status: 400, error })
+      }
+    })(req, res);
+  }, 
 };
 
 

--- a/src/v2/routes/messagesRoutes.js
+++ b/src/v2/routes/messagesRoutes.js
@@ -11,6 +11,7 @@ const router = express.Router();
 
 router.post('/', validateBody(schemas.composeMail), messagesControllers.composeMail);
 router.get('/unread', messagesControllers.unreadReceivedMails);
+router.get('/received', messagesControllers.allReceivedMails);
 router.get('/:id', messagesControllers.getSpecificMail);
 router.delete('/:id', messagesControllers.deleteSpecificMail);
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can get all received messages (inbox)


#### Description of Task to be completed?
- user can get all inbox messages
- implement router to get all received messages
- implement controller to get all received messages
- implement tests for all possible cases to get all received messages


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a **GET** request to /api/v2/messages/received


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164680671 