### PR TITLE
#164681103 Feature to GET all Sent Messages

### DIFF
--- a/src/v2/__tests__/messages.spec.js
+++ b/src/v2/__tests__/messages.spec.js
@@ -252,6 +252,7 @@ describe('User/messages actions', () => {
             res.should.have.status(200);
             res.should.be.json;
             res.body.should.have.property('data');
+            expect(res.body.data[0]).to.have.own.property('status', 'inbox');
             res.body.should.be.a('object');
             done();
           });
@@ -266,6 +267,22 @@ describe('User/messages actions', () => {
             res.should.be.json;
             res.body.should.have.property('data');
             res.body.should.be.a('object');
+            expect(res.body.data[0]).to.have.own.property('receiveremail', 'girlie@gmail.com');
+            expect(res.body.data[0]).to.have.own.property('senderemail', 'elicBalcmani2tunes@gmail.com');
+            done();
+          });
+      });
+
+      it('should return a 200 status code to get all received emails', (done) => {
+        chai.request(server)
+          .get(`${messagesRoute}/sent`)
+          .set('Authorization', `${container.token}`)
+          .end((req, res) => {
+            res.should.have.status(200);
+            res.should.be.json;
+            res.body.should.have.property('data');
+            res.body.should.be.a('object');
+            expect(res.body.data[0]).to.have.own.property('senderemail', 'elicBalcmani2tunes@gmail.com');
             done();
           });
       });

--- a/src/v2/__tests__/messages.spec.js
+++ b/src/v2/__tests__/messages.spec.js
@@ -287,4 +287,18 @@ describe('User/messages actions', () => {
           });
       });
 
+      it('should return a 404 status code when there are no sent emails', (done) => {
+        chai.request(server)
+          .get(`${messagesRoute}/sent`)
+          .set('Authorization', `${container.receiverToken}`)
+          .end((req, res) => {
+            res.should.have.status(404);
+            res.should.be.json;
+            res.body.should.have.property('error');
+            res.body.should.be.a('object');
+            expect(res.body).to.have.own.property('error', `Not Found, You do not have any sent emails at the moment`);
+            done();
+          });
+      });
+
 })

--- a/src/v2/controllers/messagesControllers.js
+++ b/src/v2/controllers/messagesControllers.js
@@ -149,6 +149,26 @@ const Mail = {
       }
     })(req, res);
   }, 
+
+  async allSentMails(req, res) {
+    passport.authenticate('jwt', {session:false}, async(err, user) => {
+      if (err) { return res.status(400).json({ status: 400, error: err }); }
+      if (!user) {
+        return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' });
+      }
+      const text = `SELECT * FROM messagesTable WHERE senderEmail=$1`;
+      const values = [user.email];
+      try {
+        const {rows} = await db.query(text, values);
+        if(!rows[0]){
+          return res.status(404).json({status: 404, error: `Not Found, You do not have any sent emails at the moment`});
+        }
+        return res.status(200).json({ status: 200, data: rows })
+      } catch (error) {
+        return res.status(400).json({status: 400, error })
+      }
+    })(req, res);
+  }, 
 };
 
 

--- a/src/v2/routes/messagesRoutes.js
+++ b/src/v2/routes/messagesRoutes.js
@@ -12,6 +12,7 @@ const router = express.Router();
 router.post('/', validateBody(schemas.composeMail), messagesControllers.composeMail);
 router.get('/unread', messagesControllers.unreadReceivedMails);
 router.get('/received', messagesControllers.allReceivedMails);
+router.get('/sent', messagesControllers.allSentMails);
 router.get('/:id', messagesControllers.getSpecificMail);
 router.delete('/:id', messagesControllers.deleteSpecificMail);
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Enables registered user to get all messages he/she sent via EPIC_Mail

#### Description of Task to be completed?
- user can get all sent messages
- create router for get all sent messages feature
- create controller for get all sent messages feature
- write tests for all cases of get all sent messages feature


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a post request to /api/v2/messages/ a multiple of times, use the same _Authorization_ header to send a **GET** request to /api/v2/messages/sent to get all sent messages


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164681103 