### PR TITLE
#164681269 Feature Enables User to Create Groups

### DIFF
--- a/src/v2/__tests__/groups.spec.js
+++ b/src/v2/__tests__/groups.spec.js
@@ -1,0 +1,45 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from './../server';
+import mockData from './mockData';
+
+chai.use(chaiHttp);
+
+const should = chai.should();
+const { expect } = chai;
+
+const { groupCreatedBy, groupDetail, groupUser } = mockData;
+
+const groupRoute = '/api/v2/groups';
+const userRoute = '/api/v2/auth';
+const messagesRoute = '/api/v2/messages';
+
+
+describe('User Interaction with groups', () => {
+    const generated = {};
+    before((done) => {
+        chai.request(server)
+            .post(`${userRoute}/signup`)
+            .set('Accept', '/application/json')
+            .send(groupCreatedBy)
+            .end((req, res) => {
+                generated.token = res.body.data[0].token;
+                done();
+            });
+    });
+
+    it('should successfully create a group', (done) => {
+        chai.request(server)
+            .post(`${groupRoute}/`)
+            .set('Authorization', `${generated.token}`)
+            .send(groupDetail)
+            .end((req, res) => {
+                res.should.have.status(201);
+                res.should.be.json;
+                res.body.should.have.property('data');
+                expect(res.body.data[0]).to.have.own.property('createdby', 'rebeccAnalize@epic_mail.com');
+                expect(res.body.data[0]).to.have.own.property('role', 'Sustaining developers growth');
+                done();
+            })
+    })
+})

--- a/src/v2/__tests__/mockData.js
+++ b/src/v2/__tests__/mockData.js
@@ -64,12 +64,31 @@ vivianUser: {
     email: 'girlie@gmail.com',
     firstName: 'girli',
     lastName: 'KÓleee',
-    password: 'thepassword'
+    password: 'thepassword',
   },
 
   anotherMessage: {
     subject: 'Developers from 1821',
     message: 'This is supposed to be a very long message, but I have nothing to write about this',
     receiverEmail: 'girlie@gmail.com',
-  }
+  }, 
+
+  groupCreatedBy: {
+    email: 'rebeccAnalize@epic_mail.com',
+    firstName: 'rebecca',
+    lastName: 'bounty',
+    password: 'bountymoney',
+  }, 
+
+  groupDetail: {
+    name: 'Developers in Michigan',
+    role: 'Sustaining developers growth',
+  },
+
+  groupUser: {
+    email: 'vicotor@epic_mail.com',
+    firstName: 'matthew',
+    lastName: 'jamal',
+    password: 'bountymoney',
+  },
 };

--- a/src/v2/controllers/groupsControllers.js
+++ b/src/v2/controllers/groupsControllers.js
@@ -1,0 +1,29 @@
+import passport from 'passport';
+import passportConf from './../passport';
+import db from './../db/index';
+
+const Group = {
+    async createGroup(req, res) {
+        passport.authenticate('jwt', {session: false}, async(err, user)=> {
+            if(err) { return res.status(400).json({ status: 400, error: err });}
+            if(!user) {
+                return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' })
+            }
+            const { role, name } = req.value.body;
+            const text = `INSERT INTO groupTable(role, name, createdBy)
+            VALUES($1, $2, $3) returning *`;
+            const values = [role, name, user.email];
+            try {
+                const { rows } = await db.query(text, values);
+                return res.status(201).json({
+                    status: 201, data: [rows[0]]
+                });
+            }catch(error){
+                return res.status(400).json({ status: 400, error})
+            }
+        })(req, res);
+    }, 
+
+}
+
+export default Group;

--- a/src/v2/db/queries.js
+++ b/src/v2/db/queries.js
@@ -52,6 +52,7 @@ const createTable = {
             id SERIAL NOT NULL UNIQUE,
             name VARCHAR(100) NOT NULL,
             createdBy VARCHAR(100) NOT NULL,
+            role VARCHAR (250),
             FOREIGN KEY(createdBy) REFERENCES usersTable(email) ON DELETE CASCADE,
             PRIMARY KEY(id, createdBy)
         )`,
@@ -59,10 +60,11 @@ const createTable = {
   groupMembersTable: `CREATE TABLE IF NOT EXISTS
         groupMembersTable(
             groupId INT NOT NULL PRIMARY KEY UNIQUE,
-            memberId INT NOT NULL,
+            userId INT NOT NULL,
             createdBy VARCHAR(100) NOT NULL,
+            userRole VARCHAR(100),
             FOREIGN KEY(groupId) REFERENCES groupTable(id) ON DELETE CASCADE,
-            FOREIGN KEY(memberId) REFERENCES usersTable(id) ON DELETE CASCADE,
+            FOREIGN KEY(userId) REFERENCES usersTable(id) ON DELETE CASCADE,
             FOREIGN KEY(createdBy) REFERENCES usersTable(email) ON DELETE CASCADE
         )`,
 

--- a/src/v2/helpers/groupsHelpers.js
+++ b/src/v2/helpers/groupsHelpers.js
@@ -1,0 +1,26 @@
+import Joi from 'joi';
+
+export default {
+    validateBody: schema => (req, res, next) => {
+        const result = Joi.validate(req.body, schema);
+        if(result.error) { 
+            return res.status(422).json({ status: 422, error: result.error });
+        }
+        if(!req.value) { req.value = {}; }
+        req.value.body = result.value;
+        next();
+    },
+
+    schemas: {
+        createGroup: Joi.object().keys({
+            name: Joi.string().required(),
+            role: Joi.string().required()
+        }),
+
+        groupMember: Joi.object().keys({
+            id: Joi.number().required(),
+            userId: Joi.number().required(),
+            userRole: Joi.string().required()
+        })
+    }
+}

--- a/src/v2/routes/groupsRoutes.js
+++ b/src/v2/routes/groupsRoutes.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import passport from 'passport';
+
+import groupsControllers from './../controllers/groupsControllers';
+import passportConf from './../passport';
+import groupHelpers from './../helpers/groupsHelpers';
+
+const { validateBody, schemas } = groupHelpers
+
+const router = express.Router();
+
+router.post('/', validateBody(schemas.createGroup), groupsControllers.createGroup);
+
+export default router;

--- a/src/v2/server.js
+++ b/src/v2/server.js
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import bodyParser from 'body-parser';
 import usersRoutes from './routes/usersRoutes';
 import messagesRoutes from './routes/messagesRoutes';
+import groupsRoutes from './routes/groupsRoutes';
 
 dotenv.config();
 
@@ -19,6 +20,7 @@ app.use(bodyParser.json());
 // Routes
 app.use('/api/v2/auth', usersRoutes);
 app.use('/api/v2/messages', messagesRoutes);
+app.use('/api/v2/groups', groupsRoutes);
 
 app.get('/', (req, res) => res.status(200).json({ status: 200, data: "'YAY!' Welcome to EPIC_Mail (version 2)" }));
 


### PR DESCRIPTION
#### What does this PR do?
User can create group

#### Description of Task to be completed?
- create controller to enable this feature
- write route that leads to create a group feature on the controller
- link the route with the server.js file
- validate all user input to create a group
- write test for all cases user to create group

#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v1/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a post request to /api/v1/groups/ to create a group


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164681269