### PR TITLE
#164682529 Feature to GET all Existing Groups

### DIFF
--- a/src/v2/__tests__/groups.spec.js
+++ b/src/v2/__tests__/groups.spec.js
@@ -15,6 +15,34 @@ const userRoute = '/api/v2/auth';
 const messagesRoute = '/api/v2/messages';
 
 
+describe('Failed group cases', () => {
+    const container = {};
+    before((done) => {
+        chai.request(server)
+            .post(`${userRoute}/signup`)
+            .set('Accept', '/application/json')
+            .send(groupUser)
+            .end((req, res) => {
+                container.token = res.body.data[0].token;
+                done();
+            });
+    });    
+
+    it('should not get any groups, since none has been created by anyone yet', (done) => {
+        chai.request(server)
+            .get(`${groupRoute}/`)
+            .set('Authorization', `${container.token}`)
+            .end((req, res) => {
+                res.should.have.status(404);
+                res.should.be.json;
+                res.body.should.have.property('error');
+                expect(res.body).to.have.own.property('error', 'There are no resgistered groups at the moment');
+                done();
+            })
+    })
+});
+
+
 describe('User Interaction with groups', () => {
     const generated = {};
     before((done) => {
@@ -39,6 +67,19 @@ describe('User Interaction with groups', () => {
                 res.body.should.have.property('data');
                 expect(res.body.data[0]).to.have.own.property('createdby', 'rebeccAnalize@epic_mail.com');
                 expect(res.body.data[0]).to.have.own.property('role', 'Sustaining developers growth');
+                done();
+            })
+    });
+
+    it('should get all existing groups', (done) => {
+        chai.request(server)
+            .get(`${groupRoute}/`)
+            .set('Authorization', `${generated.token}`)
+            .end((req, res) => {
+                res.should.have.status(200);
+                res.should.be.json;
+                res.body.should.have.property('data');
+                expect(res.body.data[0]).to.have.own.property('id', 1);
                 done();
             })
     })

--- a/src/v2/controllers/groupsControllers.js
+++ b/src/v2/controllers/groupsControllers.js
@@ -24,6 +24,26 @@ const Group = {
         })(req, res);
     }, 
 
+    async getAllGroups(req, res){
+        passport.authenticate('jwt', {session: false}, async(err, user) => {
+            if(err) { return res.status(400).json({ status: 400, error: err });
+            if(!user) {
+                return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' })
+            }}
+            const text = `SELECT * FROM groupTable`;
+            const values = [];
+            try {
+                const {rows} = await db.query(text);
+                if(!rows[0]){
+                    return res.status(404).json({ status: 404, error: 'There are no resgistered groups at the moment'});
+                }
+                return res.status(200).json({ status: 200, data: rows })
+            } catch (error) {
+                return res.status(400).json({status: 400, error})
+            }
+        })(req, res);
+    },
+
 }
 
 export default Group;

--- a/src/v2/routes/groupsRoutes.js
+++ b/src/v2/routes/groupsRoutes.js
@@ -10,5 +10,6 @@ const { validateBody, schemas } = groupHelpers
 const router = express.Router();
 
 router.post('/', validateBody(schemas.createGroup), groupsControllers.createGroup);
+router.get('/', groupsControllers.getAllGroups);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can get all existing groups

#### Description of Task to be completed?
- create route to get all existing groups
- create controller to get all existing groups
- write tests for all cases og GET existing groups


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v1/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a **GET** request to /api/v1/groups/


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164682529 