### PR TITLE
#164682631 Edit Group Name Feature

### DIFF
--- a/src/v2/__tests__/mockData.js
+++ b/src/v2/__tests__/mockData.js
@@ -85,6 +85,10 @@ vivianUser: {
     role: 'Sustaining developers growth',
   },
 
+  groupDetailValidationError: {
+    name: 'Developers in Michigan',
+  },
+
   groupUser: {
     email: 'vicotor@epic_mail.com',
     firstName: 'matthew',

--- a/src/v2/controllers/groupsControllers.js
+++ b/src/v2/controllers/groupsControllers.js
@@ -44,6 +44,36 @@ const Group = {
         })(req, res);
     },
 
+    async editGroupName(req, res) {
+        passport.authenticate('jwt', {session: false}, async(err, user) => {
+            if(err) { return res.status(400).json({ status: 400, error: err })};
+            if(!user) {
+                return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' })
+            }
+            const { id, name } = req.params;
+            const text = `SELECT * FROM groupTable 
+            WHERE id=$1`;
+            const values = [id];
+            try {
+                const { rows } = await db.query(text, values);
+                if(!rows[0]){
+                    return res.status(404).json({ status: 404, error: 'Not Found: Please check the provided groupId'})
+                }
+                if(rows[0].createdby !== user.email){
+                    return res.status(401).json({status: 401, error: 'Unauthorized, You do not have the authority to rename this group'});
+                }
+                if(rows[0].createdby === user.email){
+                    const text= `UPDATE groupTable SET name=$1 returning *`;
+                    const values = [name];
+                    const {rows} = await db.query(text, values);
+                    return res.status(200).json({status: 200, data: [rows[0]]})
+                }
+            } catch(error) {
+                return res.status(400).json({status: 400, error })
+            }
+        })(req, res);
+    }
+
 }
 
 export default Group;

--- a/src/v2/controllers/messagesControllers.js
+++ b/src/v2/controllers/messagesControllers.js
@@ -54,7 +54,7 @@ const Mail = {
         if (!rows[0]) {
           return res.status(404).json({ status: 404, error: `Not Found, you do not have a message with id=${req.params.id}` });
         }
-        // If the receiver is the one mjaking a request to the specific message
+        // If the receiver is the one making a request to the specific message
         // Then the message status should change to read if it was not yet read
         if (rows[0].status === 'inbox' && rows[0].receiveremail === user.email) {
           const updateText = `UPDATE messagesTable

--- a/src/v2/routes/groupsRoutes.js
+++ b/src/v2/routes/groupsRoutes.js
@@ -11,5 +11,6 @@ const router = express.Router();
 
 router.post('/', validateBody(schemas.createGroup), groupsControllers.createGroup);
 router.get('/', groupsControllers.getAllGroups);
+router.patch('/:id/:name', groupsControllers.editGroupName);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can Edit the Name of a Specific Group

#### Description of Task to be completed?
- create route to the name of a specific group
- create controller to edit the name of a specific group
- create dummy data to edit the name of a specific group
- write test for possible cases to be encountered in editing a group's name


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a **POST** request to /api/v2/groups/, then using the same _Authorizatio_ header, send a **PATCH** request to /api/v2/groups/:id/:name, where _:id_ and _:name_ is the id of the group whose name you intend to edit and new name of the group respectively

#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164682631 