### PR TITLE
#164682763 Feature to Delete a Specific Group

### DIFF
--- a/src/v2/__tests__/mockData.js
+++ b/src/v2/__tests__/mockData.js
@@ -95,4 +95,20 @@ vivianUser: {
     lastName: 'jamal',
     password: 'bountymoney',
   },
+
+  secondGroupDetail: {
+    name: 'Abuja boys',
+    role: 'Sweet boys, fresh guys'
+  },
+
+  loginGroupUser: {
+    email: 'vicotor@epic_mail.com',
+    password: 'bountymoney',
+  },
+
+  thirdGroupDetail: {
+    name: 'Lagos Dev community',
+    role: 'Instant communication, none-gender biased'
+  }
+
 };

--- a/src/v2/__tests__/users.spec.js
+++ b/src/v2/__tests__/users.spec.js
@@ -29,6 +29,7 @@ describe('Successful User action', () => {
   });
 
   it('should return a 200 status code for a succesful login', (done) => {
+    const container = {};
     chai.request(server)
       .post(`${userRoute}/login`)
       .set('Accept', '/application/json')
@@ -36,8 +37,10 @@ describe('Successful User action', () => {
       .end((req, res) => {
         res.should.have.status(200);
         res.should.be.json;
-        expect(res.body).to.have.property('token');
+        expect(res.body).to.have.property('data');
         res.body.should.be.a('object');
+        container.token = res.body.data[0].token;
+        expect(res.body.data[0]).to.have.own.property('token', `${container.token}`)
         done();
       });
   });

--- a/src/v2/controllers/groupsControllers.js
+++ b/src/v2/controllers/groupsControllers.js
@@ -72,6 +72,39 @@ const Group = {
                 return res.status(400).json({status: 400, error })
             }
         })(req, res);
+    },
+
+
+    async deleteSpecificGroup(req, res) {
+        passport.authenticate('jwt', {session: false}, async(err, user) => {
+            if(err) { return res.status(400).json({ status: 400, error: err })};
+            if(!user) {
+                return res.status(401).json({ status: 401, error: 'Unauthorized, Email or Password does not match' })
+            }
+            const text = `SELECT * FROM groupTable WHERE id=$1`
+            const value = [req.params.id];
+            try {
+                const {rows} = await db.query(text, value);
+                if(!rows[0]){
+                    return res.status(404).json({ status: 404, error: `Not Found, There is no group with id=${req.params.id}`});
+                }
+                if(rows[0].createdby !== user.email){
+                    return res.status(401).json({ status: 401, error: `Unauthorized, You do not have the authority to delete this group`});
+                }
+                if(rows[0].createdby === user.email) {
+                    const text = `DELETE FROM groupTable WHERE id=$1 returning *`;
+                    try {
+                        const {rows} = await db.query(text, [req.params.id]);
+                        console.log('error lies here')
+                        return res.status(200).json({ status: 200, data: 'Group has been successfully deleted'});
+                    } catch(error) {
+                        return res.status(400).json({ status: 400, error })
+                    }
+                }
+            }catch(error){
+                return res.status(400).json({status: 400, error})
+            }
+        })(req, res);
     }
 
 }

--- a/src/v2/controllers/usersControllers.js
+++ b/src/v2/controllers/usersControllers.js
@@ -66,7 +66,7 @@ class User {
         return res.status(401).json({ status: 401, error: 'User authentication error, please confirm email/password' });
       }
       const token = User.signToken(password, rows[0].password);
-      return res.status(200).json({ token });
+      return res.status(200).json({ status: 200, data: [{token}] });
     } catch (err) {
       return res.status(400).json({ status: 400, error: `${err.name}, ${err.message}` });
     }

--- a/src/v2/routes/groupsRoutes.js
+++ b/src/v2/routes/groupsRoutes.js
@@ -12,5 +12,6 @@ const router = express.Router();
 router.post('/', validateBody(schemas.createGroup), groupsControllers.createGroup);
 router.get('/', groupsControllers.getAllGroups);
 router.patch('/:id/:name', groupsControllers.editGroupName);
+router.delete('/:id', groupsControllers.deleteSpecificGroup);
 
 export default router;

--- a/src/v2/routes/usersRoutes.js
+++ b/src/v2/routes/usersRoutes.js
@@ -7,18 +7,6 @@ import passportConf from '../passport';
 
 const { validateBody, schemas } = usersHelpers;
 
-// const passportLocal = function (req, res, next) {
-//   passport.authenticate('local', { session: false }, function(err, user, info){
-//     if (err) { return next(err); }
-//     if(user) {
-//       next();
-//     }
-//     if (!user) {
-//       return res.status(401).json({ status: 401, error: 'Unauthorized, Email or password does not match' });
-//     }
-//   })(req, res, next);
-// };
-
 const router = express.Router();
 
 router.post('/signup', validateBody(schemas.authSchema), usersControllers.createUser);


### PR DESCRIPTION
#### What does this PR do?
Registered user can delete a specific group they created

#### Description of Task to be completed?
- User can delete a specific group if the group was created by them
- create route to delete specific group
- create controllers to delete a specific group
- write dummy input values for test cases
- write tests for possible cases encountered during user delete of a specific group


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a **POST** request to /api/v2/groups/ to create a group, to delete the created group launch a **DELETE** request to /api/v2/groups/:id where _:id_ is the id of the group to be deleted


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164682763 