### PR TITLE
#164682750 Feature to add User to a group

### DIFF
--- a/src/v2/__tests__/mockData.js
+++ b/src/v2/__tests__/mockData.js
@@ -109,6 +109,28 @@ vivianUser: {
   thirdGroupDetail: {
     name: 'Lagos Dev community',
     role: 'Instant communication, none-gender biased'
+  }, 
+
+  kevinUser: {
+    email: 'emeka@epic_mail.com',
+    firstName: 'emekas',
+    lastName: 'kevin',
+    password: 'eraser',
+  }, 
+
+  fourthGroupDetail: {
+    name: 'Byrant',
+    role: 'gang singns and cults'
+  },
+
+  rebecaGroup: { 
+    userEmailAddress: 'rebeccAnalize@epic_mail.com',
+    userRole: 'Qulaity Assurance'
+  }, 
+
+  elicGroup: {
+    userEmailAddress: 'elicBalcmani2tunes@gmail.com',
+    userRole: 'Hype man'
   }
 
 };

--- a/src/v2/controllers/groupsControllers.js
+++ b/src/v2/controllers/groupsControllers.js
@@ -95,7 +95,6 @@ const Group = {
                     const text = `DELETE FROM groupTable WHERE id=$1 returning *`;
                     try {
                         const {rows} = await db.query(text, [req.params.id]);
-                        console.log('error lies here')
                         return res.status(200).json({ status: 200, data: 'Group has been successfully deleted'});
                     } catch(error) {
                         return res.status(400).json({ status: 400, error })
@@ -105,7 +104,57 @@ const Group = {
                 return res.status(400).json({status: 400, error})
             }
         })(req, res);
-    }
+    }, 
+
+    async addNewMember(req, res) {
+        passport.authenticate('jwt', {session: false}, async(err, user) => {
+            if(err) { return res.status(400).json({ status: 400, error: err })}
+            if(!user) {
+                return res.status(401).json({ status: 401, error: 'Unauthorized, Email or password does not match'})
+            }
+         const text = `SELECT * FROM groupTable WHERE id=$1`;
+            const value = [req.params.id]
+
+            const {userEmailAddress, userRole} = req.value.body;
+            try {
+                const {rows} = await db.query(text, value);
+                if(!rows[0]){
+                    return res.status(404).json({ status: 404, error: `Not Found: There is no group with id=${req.params.id}`});
+                }
+                if(rows[0].createdby === user.email) {
+                    const userExistsText = `SELECT * FROM usersTable WHERE email=$1`
+                    const userExistsValue = [userEmailAddress]
+                    
+                    // Confirm if the user to be added exists in the usersTable
+                    const {rows: userExists} = await db.query(userExistsText, userExistsValue);
+                        if(!userExists[0]){
+                            return res.status(404).json({status: 404, error: `There is no registered user with the provided email`})
+                        }
+
+                        // Check if the user already exists in this group to prevent double occurence in the group
+                        const searchText=`SELECT * FROM groupmemberstable WHERE (userid=$1 AND groupId=$2)`;
+                        const searchValues = [userExists[0].id, req.params.id];
+
+                        const { rows: memberExistInGroup} = await db.query(searchText, searchValues);
+
+                        if(memberExistInGroup[0]){
+                            return res.status(409).json({ status: 409, error: 'Conflict: The email already exists in this group'});
+                        }
+                        // If the email does not already exist in the group
+                        const addMemberText = `INSERT INTO groupMembersTable(groupId, userId, userRole)
+                            VALUES($1,$2,$3) returning *`;
+                        const addMemberValue = [req.params.id, userExists[0].id, userRole]
+                        const { rows: addMemberToGroup } = await db.query(addMemberText, addMemberValue);
+                        return res.status(201).json({ status: 201, data: [addMemberToGroup[0]] })
+                        
+                        }
+                        
+                    return res.status(401).json({ status: 401, error: 'Unauthorized: You do not have the authority to add a user to this group'});
+            } catch(error) {
+                return res.status(400).json({ status: 400, error})
+            }
+        })(req, res);
+    },
 
 }
 

--- a/src/v2/db/queries.js
+++ b/src/v2/db/queries.js
@@ -59,13 +59,12 @@ const createTable = {
 
   groupMembersTable: `CREATE TABLE IF NOT EXISTS
         groupMembersTable(
-            groupId INT NOT NULL PRIMARY KEY UNIQUE,
+            groupId INT NOT NULL,
             userId INT NOT NULL,
-            createdBy VARCHAR(100) NOT NULL,
             userRole VARCHAR(100),
             FOREIGN KEY(groupId) REFERENCES groupTable(id) ON DELETE CASCADE,
             FOREIGN KEY(userId) REFERENCES usersTable(id) ON DELETE CASCADE,
-            FOREIGN KEY(createdBy) REFERENCES usersTable(email) ON DELETE CASCADE
+            PRIMARY KEY(groupId, userId)
         )`,
 
   alterMessagesTable: `ALTER TABLE messagesTable

--- a/src/v2/helpers/groupsHelpers.js
+++ b/src/v2/helpers/groupsHelpers.js
@@ -17,10 +17,9 @@ export default {
             role: Joi.string().required()
         }),
 
-        groupMember: Joi.object().keys({
-            id: Joi.number().required(),
-            userId: Joi.number().required(),
-            userRole: Joi.string().required()
-        })
+        addGroupMember: Joi.object().keys({
+            userEmailAddress: Joi.string().regex(/^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/).required(),
+            userRole: Joi.string().required(),
+        }), 
     }
 }

--- a/src/v2/routes/groupsRoutes.js
+++ b/src/v2/routes/groupsRoutes.js
@@ -9,9 +9,11 @@ const { validateBody, schemas } = groupHelpers
 
 const router = express.Router();
 
+router.post('/:id/users', validateBody(schemas.addGroupMember), groupsControllers.addNewMember);
 router.post('/', validateBody(schemas.createGroup), groupsControllers.createGroup);
 router.get('/', groupsControllers.getAllGroups);
 router.patch('/:id/:name', groupsControllers.editGroupName);
 router.delete('/:id', groupsControllers.deleteSpecificGroup);
+
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can add other users to own group


#### Description of Task to be completed?
- User can add registered members to the group
- If the user was not already in the group, then  user can be added
- Only the person who created the group can add users to the group
- input validation of data
- create tests for all possible cases of adding user to a specific group


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a **POST** request to /api/v2/groups/ to create a group with your name of choice, make a **POST** request to /api/v2/groups/:id/users to add users to the group, where _:id_ is the group id


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164682750 