### PR TITLE
#164682973 Feature to send Message to all Group Members

### DIFF
--- a/src/v2/__tests__/groups.spec.js
+++ b/src/v2/__tests__/groups.spec.js
@@ -9,7 +9,7 @@ const should = chai.should();
 const { expect } = chai;
 
 const { groupCreatedBy, groupDetail, groupUser, groupDetailValidationError, secondGroupDetail,
- loginGroupUser, thirdGroupDetail, kevinUser, fourthGroupDetail, elicGroup, rebecaGroup,
+ loginGroupUser, thirdGroupDetail, kevinUser, fourthGroupDetail, elicGroup, rebecaGroup, broadcastMessage,
  } = mockData;
 
 const groupRoute = '/api/v2/groups';
@@ -384,5 +384,45 @@ describe('Populate all group contents', () => {
             })
     })
 
-    // User does not have authority to delete member of the group
+
+    // Send a broadcast message to a group
+    it('should return 201 status code', (done) => {
+        chai.request(server)
+            .post(`${groupRoute}/4/messages`)
+            .set('Authorization', `${groupContainer.token}`)
+            .send(broadcastMessage)
+            .end((req, res) => {
+                res.should.be.json;
+                res.should.have.status(201);
+                expect(res.body.data[0]).to.have.own.property('subject', 'WuraAndFadaka');
+                done();
+            })
+    });
+
+    // There is no group with the specified id
+    it('should return 404 status code', (done) => {
+        chai.request(server)
+            .post(`${groupRoute}/17/messages`)
+            .set('Authorization', `${groupContainer.token}`)
+            .send(broadcastMessage)
+            .end((req, res) => {
+                res.should.be.json;
+                res.should.have.status(404);
+                expect(res.body).to.have.own.property('error', 'Not Found: There is no group with the specified id');
+                done();
+            })
+    });
+
+    it('should return 404 status code', (done) => {
+        chai.request(server)
+            .post(`${groupRoute}/3/messages`)
+            .set('Authorization', `${groupContainer.token}`)
+            .send(broadcastMessage)
+            .end((req, res) => {
+                res.should.be.json;
+                res.should.have.status(404);
+                expect(res.body).to.have.own.property('error', 'Not Found: There are no members in the specified group');
+                done();
+            })
+    });
 })

--- a/src/v2/__tests__/messages.spec.js
+++ b/src/v2/__tests__/messages.spec.js
@@ -74,7 +74,7 @@ describe('Succesful User message actions', () => {
 
   it('should return a 200 status code for an existing specific message', (done) => {
     chai.request(server)
-      .get(`${messagesRoute}/1`)
+      .get(`${messagesRoute}/2`)
       .set('Authorization', `${generated.token}`)
       .end((req, res) => {
         res.should.have.status(200);

--- a/src/v2/__tests__/mockData.js
+++ b/src/v2/__tests__/mockData.js
@@ -131,6 +131,11 @@ vivianUser: {
   elicGroup: {
     userEmailAddress: 'elicBalcmani2tunes@gmail.com',
     userRole: 'Hype man'
+  }, 
+
+  broadcastMessage: {
+    subject: "WuraAndFadaka",
+    message: "A great inspiration"
   }
 
 };

--- a/src/v2/helpers/groupsHelpers.js
+++ b/src/v2/helpers/groupsHelpers.js
@@ -20,6 +20,12 @@ export default {
         addGroupMember: Joi.object().keys({
             userEmailAddress: Joi.string().regex(/^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/).required(),
             userRole: Joi.string().required(),
-        }), 
+        }),
+        
+        broadCastMessage: Joi.object().keys({
+            subject: Joi.string().required(),
+            message: Joi.string().required(),
+            parentMessagedId: Joi.number(),
+        })
     }
 }

--- a/src/v2/routes/groupsRoutes.js
+++ b/src/v2/routes/groupsRoutes.js
@@ -15,6 +15,7 @@ router.get('/', groupsControllers.getAllGroups);
 router.patch('/:id/:name', groupsControllers.editGroupName);
 router.delete('/:id', groupsControllers.deleteSpecificGroup);
 router.delete('/:groupId/users/:userId', groupsControllers.deleteSpecificUserFromGroup);
+router.post('/:groupId/messages/', validateBody(schemas.broadCastMessage), groupsControllers.broadcastMessage);
 
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
User can send a message to an existing group


#### Description of Task to be completed?
- Any user can send a message to all members of a group
- write test cases for all possible scenarios when sending a message to group members
- Adjust other tests to suit new tests id number


#### How should this be manually tested?
Clone the repo, cd into it and run **npm run dev-start**, make a **POST** request to /api/v2/auth/signup/, copy the received token and use as the value for _Authorization_ header when sending a **POST** request to /api/v2/groups/ to create a new group, add new members to the group and send a message to the group by specifying the groupId in the paramter (check readMe.md).


#### Any background context you want to provide?
Ensure that all required data are provided to avoid validation error


#### What are the relevant pivotal tracker stories?
#164682973 